### PR TITLE
SECURITY: Bump pillow from 4.0.0 to 6.2.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,3 +36,32 @@ Here is an example of mixin usage:
     exporter = PyDocXHTMLExporterWithResizedImages(docx_path)
 
     html = exporter.export()
+
+
+Running Tests
+============
+
+Ensure you have have prerequisites:
+
+pyenv:
+
+.. code-block:: console
+
+    brew install pyenv
+
+python runtimes:
+
+.. code-block:: console
+
+    pyenv install 2.7.16
+    pyenv install 3.8.5
+
+install and run tox:
+
+.. code-block:: console
+
+    pyenv local 3.8.5
+    pip install tox tox-pyenv
+    tox
+
+Note that 'doctest' is only used in 'pydocxresizeimages/util/uri.py'

--- a/pydocxresizeimages/util/uri.py
+++ b/pydocxresizeimages/util/uri.py
@@ -10,7 +10,7 @@ import posixpath
 
 from six.moves.urllib.parse import unquote
 
-regexp_pattern = 'data:image/(?P<extension>\w+);base64,(?P<image_data>.+)'
+regexp_pattern = r'data:image/(?P<extension>\w+);base64,(?P<image_data>.+)'
 
 IMAGE_DATA_URI_REGEX = {
     'bytes': re.compile(regexp_pattern.encode()),
@@ -38,7 +38,7 @@ def sanitize_filename(filename):
     and dash. When images come from docx they are always `image\d+`. We only
     want to strip off the timestamp and dash if they were programmatically
     added.
-    """
+    """ # noqa
 
     # (timestamp)-image(image_number).(file_extension)
     regex = re.compile(r'\d{10}-image\d+\.\w{3,4}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests>=2.7.0
-Pillow>=6.2.2
-six>=1.10.0
+requests==2.7.0
+Pillow==6.2.2
+six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.7.0
-Pillow>=4.0.0
+Pillow>=6.2.2
 six>=1.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,31 +4,15 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = docs, py{27,34}pep8, py{26,27,33,34,py}, py{26,27,33,34,py}-defusedxml, py{27,34}-coverage
+envlist = py{27,38}
 
 [testenv]
-commands =
-  nosetests --with-doctest []
 deps =
+  -rrequirements.txt
   -rtests/requirements.txt
-
-# Coverage for python 2.7 and and 3.4 only
-[testenv:py27-coverage]
 commands =
-  nosetests --with-doctest --with-coverage --cover-package pydocxresizeimages []
-[testenv:py34-coverage]
-commands =
-  nosetests --with-doctest --with-coverage --cover-package pydocxresizeimages []
-
-[testenv:py27pep8]
-basepython = python2.7
-deps = flake8
-commands = flake8 pydocxresizeimages
-
-[testenv:py34pep8]
-basepython = python3.4
-deps = flake8
-commands = flake8 pydocxresizeimages
+  nosetests --verbose --with-doctest --with-coverage --cover-erase --cover-package pydocxresizeimages
+  flake8 pydocxresizeimages
 
 [flake8]
 select = E,W,F


### PR DESCRIPTION
### Changes
1. Cleans up test execution and gets them passing.
2. Bumps Pillow dep from 4.0.0 to 6.2.2

### Background

Pillow < 6.2.2 has a number of vulnerabilities. This version is as high as we can go with python 2.7 (our EOL production version). Four more CVEs are remediated with 7.1.0 (CVE-2020-11538, CVE-2020-10994, CVE-2020-10177, CVE-2020-10379).

The [changelog](https://pillow.readthedocs.io/en/stable/releasenotes/6.2.2.html) doesn't reveal anything that affects this package (just uses it to resize).

[CVE-2019-19911](https://github.com/advisories/GHSA-5gm3-px64-rw72)
moderate severity
Vulnerable versions: < 6.2.2
Patched version: 6.2.2
There is a DoS vulnerability in Pillow before 6.2.2 caused by FpxImagePlugin.py calling the range function on an unvalidated 32-bit integer if the number of bands is large. On Windows running 32-bit Python, this results in an OverflowError or MemoryError due to the 2 GB limit. However, on Linux running 64-bit Python this results in the process being terminated by the OOM killer.

[CVE-2020-5313](https://github.com/advisories/GHSA-hj69-c76v-86wr)
moderate severity
Vulnerable versions: < 6.2.2
Patched version: 6.2.2
libImaging/FliDecode.c in Pillow before 6.2.2 has an FLI buffer overflow.

[CVE-2019-16865](https://github.com/advisories/GHSA-j7mj-748x-7p78)
low severity
Vulnerable versions: < 6.2.0
Patched version: 6.2.0
An issue was discovered in Pillow before 6.2.0. When reading specially crafted invalid image files, the library can either allocate very large amounts of memory or take an extremely long period of time to process the image.

### Successful test and quality check on 2.7 and 3.8

```
tox
GLOB sdist-make: /Users/andy/dev/projects/pydocx-resize-images/setup.py
py27 inst-nodeps: /Users/andy/dev/projects/pydocx-resize-images/.tox/.tmp/package/1/pydocxresizeimages-0.0.3.zip
py27 installed: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support,certifi==2020.6.20,chardet==3.0.4,configparser==4.0.2,contextlib2==0.6.0.post1,cookies==2.2.1,coverage==5.2.1,enum34==1.1.10,flake8==3.8.3,funcsigs==1.0.2,functools32==3.2.3.post2,idna==2.10,importlib-metadata==1.7.0,mccabe==0.6.1,mock==3.0.5,nose==1.3.7,olefile==0.46,pathlib2==2.3.5,Pillow==4.0.0,pycodestyle==2.6.0,-e git://github.com/CenterForOpenScience/pydocx.git@98c6aa626d875278240eabea8f86a914840499b3#egg=PyDocX,pydocxresizeimages==0.0.3,pyflakes==2.2.0,requests==2.24.0,responses==0.11.0,scandir==1.10.0,six==1.15.0,typing==3.7.4.3,urllib3==1.25.10,zipp==1.2.0
py27 run-test-pre: PYTHONHASHSEED='1807139735'
py27 run-test: commands[0] | nosetests --verbose --with-doctest --with-coverage --cover-erase --cover-package pydocxresizeimages
Doctest: pydocxresizeimages.util.uri.uri_is_external ... ok
Doctest: pydocxresizeimages.util.uri.uri_is_internal ... ok
test_export_docx_to_resized_images (tests.mixins.test_image_resize.PyDocXHTMLExporterWithResizedImagesTestCase) ... ok
test_export_docx_to_resized_images_images_width_and_height_as_pt (tests.mixins.test_image_resize.PyDocXHTMLExporterWithResizedImagesTestCase) ... ok
test_export_docx_to_resized_images_images_with_same_id (tests.mixins.test_image_resize.PyDocXHTMLExporterWithResizedImagesTestCase) ... ok
test_export_docx_to_resized_images_rotate_image (tests.mixins.test_image_resize.PyDocXHTMLExporterWithResizedImagesTestCase) ... ok
test_get_image_tag_external_uri (tests.mixins.test_image_resize.ResizedImagesExportMixinTestCase) ... ok
test_get_image_tag_has_skippable_extension (tests.mixins.test_image_resize.ResizedImagesExportMixinTestCase) ... ok
test_get_image_data_and_filename (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_data_and_filename_empty_filename (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_data_and_filename_empty_input (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_format (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_from_src_data (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_from_src_invalid_data (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_from_src_url (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_is_encoded_image_uri (tests.util.test_uri.UriUtilsTestCase) ... ok
test_sanitize_filename (tests.util.test_uri.UriUtilsTestCase) ... ok
test_has_height_and_width_false (tests.test_image_resize.ImageResizerTestCase) ... ok
test_has_height_and_width_true (tests.test_image_resize.ImageResizerTestCase) ... ok
test_has_skipable_extension_false (tests.test_image_resize.ImageResizerTestCase) ... ok
test_has_skipable_extension_invalid_filename (tests.test_image_resize.ImageResizerTestCase) ... ok
test_has_skipable_extension_true (tests.test_image_resize.ImageResizerTestCase) ... ok
test_height_and_width_as_pt (tests.test_image_resize.ImageResizerTestCase) ... ok
test_height_as_pt_width_as_px (tests.test_image_resize.ImageResizerTestCase) ... ok
test_init_image (tests.test_image_resize.ImageResizerTestCase) ... ok
test_init_image_exception (tests.test_image_resize.ImageResizerTestCase) ... ok
test_init_image_with_data_should_be_the_same (tests.test_image_resize.ImageResizerTestCase) ... ok
test_init_object (tests.test_image_resize.ImageResizerTestCase) ... ok
test_invalid_dimention_error (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_change_to_gif (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_keep_original (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_not_resized (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_raise_exception (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_skip (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_success (tests.test_image_resize.ImageResizerTestCase) ... ok
test_update_filename (tests.test_image_resize.ImageResizerTestCase) ... ok
test_update_filename_empty_filename (tests.test_image_resize.ImageResizerTestCase) ... ok
test_update_filename_empty_filename_with_extension (tests.test_image_resize.ImageResizerTestCase) ... ok
test_update_filename_to_gif (tests.test_image_resize.ImageResizerTestCase) ... ok

Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
pydocxresizeimages/__init__.py                  3      0   100%
pydocxresizeimages/image_resize.py             80      1    99%   120
pydocxresizeimages/mixins/__init__.py           0      0   100%
pydocxresizeimages/mixins/image_resize.py      30      0   100%
pydocxresizeimages/util/__init__.py             0      0   100%
pydocxresizeimages/util/image.py               32      0   100%
pydocxresizeimages/util/uri.py                 29      0   100%
-------------------------------------------------------------------------
TOTAL                                         174      1    99%
----------------------------------------------------------------------
Ran 39 tests in 0.746s

OK
py27 run-test: commands[1] | flake8 pydocxresizeimages
py38 inst-nodeps: /Users/andy/dev/projects/pydocx-resize-images/.tox/.tmp/package/1/pydocxresizeimages-0.0.3.zip
py38 installed: certifi==2020.6.20,chardet==3.0.4,coverage==5.2.1,flake8==3.8.3,idna==2.10,mccabe==0.6.1,nose==1.3.7,olefile==0.46,Pillow==7.2.0,pycodestyle==2.6.0,-e git://github.com/CenterForOpenScience/pydocx.git@98c6aa626d875278240eabea8f86a914840499b3#egg=PyDocX,pydocxresizeimages==0.0.3,pyflakes==2.2.0,requests==2.24.0,responses==0.11.0,six==1.15.0,urllib3==1.25.10
py38 run-test-pre: PYTHONHASHSEED='1807139735'
py38 run-test: commands[0] | nosetests --verbose --with-doctest --with-coverage --cover-erase --cover-package pydocxresizeimages
Doctest: pydocxresizeimages.util.uri.uri_is_external ... ok
Doctest: pydocxresizeimages.util.uri.uri_is_internal ... ok
test_export_docx_to_resized_images (tests.mixins.test_image_resize.PyDocXHTMLExporterWithResizedImagesTestCase) ... ok
test_export_docx_to_resized_images_images_width_and_height_as_pt (tests.mixins.test_image_resize.PyDocXHTMLExporterWithResizedImagesTestCase) ... ok
test_export_docx_to_resized_images_images_with_same_id (tests.mixins.test_image_resize.PyDocXHTMLExporterWithResizedImagesTestCase) ... ok
test_export_docx_to_resized_images_rotate_image (tests.mixins.test_image_resize.PyDocXHTMLExporterWithResizedImagesTestCase) ... ok
test_get_image_tag_external_uri (tests.mixins.test_image_resize.ResizedImagesExportMixinTestCase) ... ok
test_get_image_tag_has_skippable_extension (tests.mixins.test_image_resize.ResizedImagesExportMixinTestCase) ... ok
test_get_image_data_and_filename (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_data_and_filename_empty_filename (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_data_and_filename_empty_input (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_format (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_from_src_data (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_from_src_invalid_data (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_get_image_from_src_url (tests.util.test_image.GetImageDataAndFileNameTestCase) ... ok
test_is_encoded_image_uri (tests.util.test_uri.UriUtilsTestCase) ... ok
test_sanitize_filename (tests.util.test_uri.UriUtilsTestCase) ... ok
test_has_height_and_width_false (tests.test_image_resize.ImageResizerTestCase) ... ok
test_has_height_and_width_true (tests.test_image_resize.ImageResizerTestCase) ... ok
test_has_skipable_extension_false (tests.test_image_resize.ImageResizerTestCase) ... ok
test_has_skipable_extension_invalid_filename (tests.test_image_resize.ImageResizerTestCase) ... ok
test_has_skipable_extension_true (tests.test_image_resize.ImageResizerTestCase) ... ok
test_height_and_width_as_pt (tests.test_image_resize.ImageResizerTestCase) ... ok
test_height_as_pt_width_as_px (tests.test_image_resize.ImageResizerTestCase) ... ok
test_init_image (tests.test_image_resize.ImageResizerTestCase) ... ok
test_init_image_exception (tests.test_image_resize.ImageResizerTestCase) ... ok
test_init_image_with_data_should_be_the_same (tests.test_image_resize.ImageResizerTestCase) ... ok
test_init_object (tests.test_image_resize.ImageResizerTestCase) ... ok
test_invalid_dimention_error (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_change_to_gif (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_keep_original (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_not_resized (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_raise_exception (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_skip (tests.test_image_resize.ImageResizerTestCase) ... ok
test_resize_image_success (tests.test_image_resize.ImageResizerTestCase) ... ok
test_update_filename (tests.test_image_resize.ImageResizerTestCase) ... ok
test_update_filename_empty_filename (tests.test_image_resize.ImageResizerTestCase) ... ok
test_update_filename_empty_filename_with_extension (tests.test_image_resize.ImageResizerTestCase) ... ok
test_update_filename_to_gif (tests.test_image_resize.ImageResizerTestCase) ... ok

Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
pydocxresizeimages/__init__.py                  3      0   100%
pydocxresizeimages/image_resize.py             80      1    99%   120
pydocxresizeimages/mixins/__init__.py           0      0   100%
pydocxresizeimages/mixins/image_resize.py      30      0   100%
pydocxresizeimages/util/__init__.py             0      0   100%
pydocxresizeimages/util/image.py               32      0   100%
pydocxresizeimages/util/uri.py                 29      0   100%
-------------------------------------------------------------------------
TOTAL                                         174      1    99%
----------------------------------------------------------------------
Ran 39 tests in 1.197s

OK
py38 run-test: commands[1] | flake8 pydocxresizeimages
__________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________
  py27: commands succeeded
  py38: commands succeeded
  congratulations :)
```

### QA
The tests seem adequate but I did some manual QA to be sure before and after (bump of pillow) checksums matched.

```
MD5 (cloned_images.html) = c3fa82213603e5ca92105cf7aa7bd14d (4.0.0)
MD5 (cloned_images.html) = c3fa82213603e5ca92105cf7aa7bd14d (6.2.2)
MD5 (tests/fixtures/cloned_images.html) = c3fa82213603e5ca92105cf7aa7bd14d (orig)

MD5 (image_with_pt_dimensions.html) = bd8b292e55fd1ac73f3fc079cf69e60a (4.0.0)
MD5 (image_with_pt_dimensions.html) = bd8b292e55fd1ac73f3fc079cf69e60a (6.2.2)
MD5 (tests/fixtures/image_with_pt_dimensions.html) = bd8b292e55fd1ac73f3fc079cf69e60a (orig)

MD5 (png_basic_resize_linked_photo.html) = 31be6507c54e8e8978f7516f1494f4e0 (4.0.0)
MD5 (png_basic_resize_linked_photo.html) = 31be6507c54e8e8978f7516f1494f4e0 (6.2.2)
MD5 (tests/fixtures/png_basic_resize_linked_photo.html) = 31be6507c54e8e8978f7516f1494f4e0 (orig)

MD5 (rotate_image.html) = 4e18920f9e0ee934691262088541ac45 (4.0.0)
MD5 (rotate_image.html) = 4e18920f9e0ee934691262088541ac45 (6.2.2)
MD5 (tests/fixtures/rotate_image.html) = 4e18920f9e0ee934691262088541ac45 (orig)

same size
MD5 (image1_same_size.png) = 5cca6069f68fbf739fce37e0963f21e7 (4.0.0)
MD5 (image1.png) = 5cca6069f68fbf739fce37e0963f21e7 (6.2.2)
MD5 (tests/fixtures/image1.png) = 5cca6069f68fbf739fce37e0963f21e7 (orig)

diff size
MD5 (image1.png) = 3da6b6269e0750e2c8440915b4647e14 (4.0.0)
MD5 (image1.png) = 3da6b6269e0750e2c8440915b4647e14 (6.2.2)
MD5 (tests/fixtures/image1.png) = 5cca6069f68fbf739fce37e0963f21e7 (orig)
```