### PR TITLE
INTERNAL: Skip image resize of "self-hosted" images

### DIFF
--- a/pydocxresizeimages/mixins/image_resize.py
+++ b/pydocxresizeimages/mixins/image_resize.py
@@ -7,49 +7,55 @@ from __future__ import (
 )
 
 from ..util.image import get_image_data_and_filename
-from ..util.uri import uri_is_external, get_uri_filename
+from ..util.uri import uri_is_external, uri_is_self_hosted, get_uri_filename
 from ..image_resize import ImageResizer
 
 
 class ResizedImagesExportMixin(object):
+    def __init__(self, *args, **kwargs):
+        self.s3_bucket = kwargs.pop('s3_bucket', '')
+
+        super(ResizedImagesExportMixin, self).__init__(s3_bucket=self.s3_bucket, *args, **kwargs)
+
     def get_image_tag(self, image, width=None, height=None, **kwargs):
         if self.first_pass or not image:
             return ''
 
-        filename = get_uri_filename(image.uri)
-        external_image = uri_is_external(image.uri)
-        if external_image:
-            image_data, filename = get_image_data_and_filename(
-                image.uri,
-                filename,
-            )
-        else:
-            image.stream.seek(0)
-            image_data = image.stream.read()
-
-        image_resizer = ImageResizer(image_data, filename, width, height)
-
-        if image_resizer.has_skippable_extension():
-            return ''
-
-        if not image_resizer.has_height_and_width():
-            return ''
-
-        image_resizer.init_image()
-        img_resized = image_resizer.resize_image()
-
-        if img_resized:
-            image_resizer.update_filename()
-
-            if not external_image:
-                # clear current stream content
+        if not uri_is_self_hosted(image.uri, self.s3_bucket):
+            filename = get_uri_filename(image.uri)
+            external_image = uri_is_external(image.uri)
+            if external_image:
+                image_data, filename = get_image_data_and_filename(
+                    image.uri,
+                    filename,
+                )
+            else:
                 image.stream.seek(0)
-                image.stream.truncate(0)
+                image_data = image.stream.read()
 
-                # replace the image stream with a new resized image
-                image.stream.write(image_resizer.image_data)
+            image_resizer = ImageResizer(image_data, filename, width, height)
 
-            width = image_resizer.width
-            height = image_resizer.height
+            if image_resizer.has_skippable_extension():
+                return ''
+
+            if not image_resizer.has_height_and_width():
+                return ''
+
+            image_resizer.init_image()
+            img_resized = image_resizer.resize_image()
+
+            if img_resized:
+                image_resizer.update_filename()
+
+                if not external_image:
+                    # clear current stream content
+                    image.stream.seek(0)
+                    image.stream.truncate(0)
+
+                    # replace the image stream with a new resized image
+                    image.stream.write(image_resizer.image_data)
+
+                width = image_resizer.width
+                height = image_resizer.height
 
         return super(ResizedImagesExportMixin, self, ).get_image_tag(image, width, height, **kwargs)

--- a/pydocxresizeimages/util/uri.py
+++ b/pydocxresizeimages/util/uri.py
@@ -75,6 +75,15 @@ def uri_is_external(uri):
     """
     return not uri_is_internal(uri)
 
+def uri_is_self_hosted(uri, bucket_name=''):
+    """
+    >>> uri_is_self_hosted('https://cdn-retailzipline-dev.s3.amazonaws.com/o/zipline/communications/0624df82-6090-4b32-8e57-6a4a96d57ae9/168814738383343-image1.png')
+    True
+    >>> uri_is_self_hosted('http://google/images/image.png')
+    False
+    """
+    s3_bucket_url = "https://%s.s3.amazonaws.com" % (bucket_name)
+    return uri.startswith(s3_bucket_url)
 
 def get_uri_filename(uri):
     _, filename = posixpath.split(uri)


### PR DESCRIPTION
🎁 Summary
---
Adds support for specifying an S3 bucket name that is considered "internal", such that the resize step is skipped.


☎️ Related links and discussions
---
https://github.com/retailzipline/zipline-app/issues/20852


✋ Deployment Dependencies
---
- [ ] https://github.com/retailzipline/pydocx-s3-images/pull/3
- [ ] https://github.com/retailzipline/docx2html/pull/232
